### PR TITLE
fix: remove unnecessary WAV conversion (#6)

### DIFF
--- a/tests/transcribe.test.js
+++ b/tests/transcribe.test.js
@@ -16,6 +16,8 @@ const {
   findWhisperBinary, 
   selectModel, 
   parseArgs,
+  isSupportedFormat,
+  SUPPORTED_FORMATS,
   DEFAULTS 
 } = transcribeModule;
 
@@ -124,6 +126,8 @@ function testScriptExists() {
   assertTrue(content.includes('findWhisperBinary'), 'Script has whisper binary detection');
   assertTrue(content.includes('selectModel'), 'Script has smart model selection');
   assertTrue(content.includes('checkDependencies'), 'Script has dependency checking');
+  assertTrue(content.includes('isSupportedFormat'), 'Script has format validation (no WAV conversion)');
+  assertTrue(content.includes('SUPPORTED_FORMATS'), 'Script defines supported formats');
   assertTrue(content.includes('WHISPER_MODEL'), 'Script uses WHISPER_MODEL env var');
   assertTrue(content.includes('WHISPER_LANGUAGE'), 'Script uses WHISPER_LANGUAGE env var');
 }
@@ -308,11 +312,47 @@ function testModuleExports() {
   assertTrue(typeof transcribeModule.findWhisperBinary === 'function', 'Exports findWhisperBinary function');
   assertTrue(typeof transcribeModule.selectModel === 'function', 'Exports selectModel function');
   assertTrue(typeof transcribeModule.parseArgs === 'function', 'Exports parseArgs function');
+  assertTrue(typeof transcribeModule.isSupportedFormat === 'function', 'Exports isSupportedFormat function');
+  assertTrue(Array.isArray(transcribeModule.SUPPORTED_FORMATS), 'Exports SUPPORTED_FORMATS array');
   assertTrue(typeof transcribeModule.DEFAULTS === 'object', 'Exports DEFAULTS object');
 }
 
 /**
- * Test 9: CLI help output
+ * Test 9: Direct format support (no WAV conversion needed)
+ */
+function testDirectFormatSupport() {
+  console.log('\n🎵 Test Suite: Direct Format Support (Issue #6)');
+  
+  // Test that all supported formats are recognized
+  assertTrue(isSupportedFormat('audio.wav'), 'Supports WAV format');
+  assertTrue(isSupportedFormat('audio.mp3'), 'Supports MP3 format');
+  assertTrue(isSupportedFormat('audio.m4a'), 'Supports M4A format');
+  assertTrue(isSupportedFormat('audio.flac'), 'Supports FLAC format');
+  assertTrue(isSupportedFormat('audio.ogg'), 'Supports OGG format');
+  
+  // Test case insensitivity
+  assertTrue(isSupportedFormat('audio.MP3'), 'Supports uppercase MP3 format');
+  assertTrue(isSupportedFormat('audio.WAV'), 'Supports uppercase WAV format');
+  
+  // Test unsupported formats
+  assertEqual(isSupportedFormat('audio.wma'), false, 'Rejects WMA format');
+  assertEqual(isSupportedFormat('audio.aac'), false, 'Rejects AAC format');
+  assertEqual(isSupportedFormat('audio.unknown'), false, 'Rejects unknown format');
+  
+  // Verify no convertToWav is exported (it was removed)
+  assertEqual(typeof transcribeModule.convertToWav, 'undefined', 'convertToWav function removed from exports');
+  
+  // Verify supported formats list
+  assertTrue(SUPPORTED_FORMATS.includes('.wav'), 'SUPPORTED_FORMATS includes .wav');
+  assertTrue(SUPPORTED_FORMATS.includes('.mp3'), 'SUPPORTED_FORMATS includes .mp3');
+  assertTrue(SUPPORTED_FORMATS.includes('.m4a'), 'SUPPORTED_FORMATS includes .m4a');
+  assertTrue(SUPPORTED_FORMATS.includes('.flac'), 'SUPPORTED_FORMATS includes .flac');
+  assertTrue(SUPPORTED_FORMATS.includes('.ogg'), 'SUPPORTED_FORMATS includes .ogg');
+  assertEqual(SUPPORTED_FORMATS.length, 5, 'Exactly 5 supported formats');
+}
+
+/**
+ * Test 10: CLI help output
  */
 function testCliHelp() {
   console.log('\n📖 Test Suite: CLI Help');
@@ -356,6 +396,7 @@ function runTests() {
     testWhisperBinaryDetection();
     testOldScriptsRemoved();
     testModuleExports();
+    testDirectFormatSupport();
     testCliHelp();
   } catch (e) {
     console.error('\n💥 Test suite error:', e.message);

--- a/transcribe.js
+++ b/transcribe.js
@@ -145,24 +145,17 @@ function showInstallInstructions() {
 }
 
 /**
- * Convert audio to WAV format (Whisper requirement)
+ * Supported audio formats (Whisper CLI accepts these directly)
+ * No conversion needed for these formats
  */
-function convertToWav(audioPath) {
-  console.log('\n🎵 Converting audio to WAV format...');
-  
-  const wavPath = audioPath.replace(/\.[^/.]+$/, '.wav');
-  
-  try {
-    execSync(`ffmpeg -i "${audioPath}" -ar 16000 -ac 1 -acodec pcm_s16le "${wavPath}" -y`, {
-      encoding: 'utf-8',
-      stdio: 'pipe'
-    });
-    
-    console.log(`✅ Converted: ${path.basename(wavPath)}`);
-    return wavPath;
-  } catch (error) {
-    throw new Error(`Conversion failed: ${error.message}`);
-  }
+const SUPPORTED_FORMATS = ['.wav', '.mp3', '.m4a', '.flac', '.ogg'];
+
+/**
+ * Check if audio format is supported by Whisper CLI
+ */
+function isSupportedFormat(audioPath) {
+  const ext = path.extname(audioPath).toLowerCase();
+  return SUPPORTED_FORMATS.includes(ext);
 }
 
 /**
@@ -242,7 +235,7 @@ function transcribeWithWhisper(inputPath, options = {}) {
 /**
  * Main transcription function
  */
-async function transcribe(audioPath, options = {}) {
+function transcribe(audioPath, options = {}) {
   console.log(`\n🎙️ Whisper Voice Transcription`);
   console.log('='.repeat(50));
   console.log(`📁 Input: ${audioPath}`);
@@ -253,16 +246,14 @@ async function transcribe(audioPath, options = {}) {
     throw new Error(`Audio file not found: ${audioPath}`);
   }
   
-  // Convert to WAV if needed
-  let inputPath = audioPath;
-  const ext = path.extname(audioPath).toLowerCase();
-  
-  if (ext !== '.wav') {
-    inputPath = convertToWav(audioPath);
+  // Validate audio format
+  if (!isSupportedFormat(audioPath)) {
+    const ext = path.extname(audioPath).toLowerCase() || 'unknown';
+    throw new Error(`Unsupported audio format: ${ext}. Supported formats: ${SUPPORTED_FORMATS.join(', ')}`);
   }
   
-  // Transcribe
-  const result = transcribeWithWhisper(inputPath, options);
+  // Transcribe directly (Whisper CLI supports MP3, M4A, FLAC, OGG natively)
+  const result = transcribeWithWhisper(audioPath, options);
   
   console.log('\n' + '='.repeat(50));
   console.log('📝 Transcription:');
@@ -354,7 +345,7 @@ USAGE:
   node transcribe.js <audio_file> [OPTIONS]
 
 ARGUMENTS:
-  audio_file              Path to audio file (OGG, MP3, WAV, M4A, FLAC)
+  audio_file              Path to audio file (WAV, MP3, M4A, FLAC, OGG)
 
 OPTIONS:
   --model <model>         Model size: tiny, base, small, medium, large
@@ -422,7 +413,7 @@ async function main() {
   }
   
   try {
-    await transcribe(audioPath, options);
+    transcribe(audioPath, options);
     process.exit(0);
   } catch (error) {
     console.error(`\n❌ Error: ${error.message}`);
@@ -441,7 +432,8 @@ module.exports = {
   checkDependencies,
   findWhisperBinary,
   selectModel,
-  convertToWav,
+  isSupportedFormat,
+  SUPPORTED_FORMATS,
   parseArgs,
   DEFAULTS
 };


### PR DESCRIPTION
## Summary
Removes unnecessary WAV conversion since Whisper CLI accepts MP3, M4A, FLAC, OGG directly.

## Changes
- Removed `convertToWav()` function and related code
- Added `SUPPORTED_FORMATS` constant and `isSupportedFormat()` validation
- Updated `transcribe()` to pass audio files directly to Whisper CLI
- Updated tests to verify direct format support for all 5 formats

## Testing
All 70 tests pass:
- Format validation for WAV, MP3, M4A, FLAC, OGG
- Case insensitivity
- Rejection of unsupported formats
- Module exports verification

Closes #6