### PR TITLE
docs: slim down SKILL.md (#7)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,233 +1,46 @@
 ---
 name: local-whisper
-description: LOCAL voice transcription using OpenAI Whisper (no cloud API, full privacy). Supports English, German, and 97+ languages with automatic detection.
-homepage: https://github.com/openai/whisper
+description: LOCAL voice transcription using OpenAI Whisper. 100% private - audio never leaves your machine. Supports 97+ languages.
+homepage: https://github.com/kesslerio/local-whisper-openclaw-skill
 metadata: {"openclaw":{"emoji":"🎙️","requires":{"bins":["whisper","ffmpeg"]},"install":[{"id":"pip","kind":"pip","package":"openai-whisper","bins":["whisper"],"label":"Install Whisper (pip)"}]}}
 ---
 
-# 🎙️ Whisper Voice Transcription (LOCAL)
+# 🎙️ Local Whisper Transcription
 
-**100% Private, 100% Local, No API Keys Required!**
-
-Transcribe WhatsApp voice messages using OpenAI Whisper installed locally on your machine.
-
-## Why Local?
-
-✅ **Privacy** - Audio never leaves your machine  
-✅ **No API Costs** - Free after installation  
-✅ **No Rate Limits** - Unlimited transcription  
-✅ **Fast** - No network latency  
-✅ **Offline** - Works without internet  
-
-## Installation
-
-### Step 1: Install FFmpeg
-**FFmpeg** converts WhatsApp OGG/Opus audio to WAV format.
-
-```bash
-# NixOS (add to /etc/nixos/configuration.nix):
-environment.systemPackages = with pkgs; [ ffmpeg ];
-
-# Apply: sudo nixos-rebuild switch
-
-# Or on other systems:
-# macOS: brew install ffmpeg
-# Ubuntu: sudo apt install ffmpeg
-# Arch: sudo pacman -S ffmpeg
-```
-
-### Step 2: Install OpenAI Whisper
-**Whisper** does the actual transcription.
-
-```bash
-# Install Python and pip (if not installed)
-# NixOS: python3 usually available
-
-# Install Whisper
-pip install openai-whisper ffmpeg-python
-
-# Or with GPU support (if you have NVIDIA):
-pip install openai-whisper[torch]
-
-# Verify installation
-whisper --help
-```
-
-### Step 3: Test It
-```bash
-# Check dependencies
-node ~/.openclaw/skills/whisper/transcribe.js --check
-
-# Test with a voice message
-node ~/.openclaw/skills/whisper/transcribe.js ~/.openclaw/media/inbound/voice.ogg
-```
-
-## Usage
-
-### Basic Usage
-```bash
-# Transcribe with auto-detect language and smart model selection
-node transcribe.js <audio_file>
-
-# Example:
-node transcribe.js voice.ogg
-```
-
-### Command Line Options
-
-| Option | Short | Description | Default |
-|--------|-------|-------------|---------|
-| `--model` | | Model size: tiny, base, small, medium, large | `small` |
-| `--language` | `-l` | Language code: auto, en, de, es, fr, etc. | `auto` |
-| `--output-dir` | `-o` | Output directory for transcriptions | Same as input |
-| `--smart-model` | | Enable smart model selection | Enabled |
-| `--no-smart-model` | | Disable smart model selection | - |
-| `--check` | `-c` | Check dependencies | - |
-| `--help` | `-h` | Show help | - |
-| `--version` | `-v` | Show version | - |
-
-### Examples
-
-```bash
-# Auto-detect language with smart model selection (recommended)
-node transcribe.js voice.ogg
-
-# Specify language
-node transcribe.js voice.ogg --language de
-node transcribe.js voice.mp3 --language en
-
-# Use specific model
-node transcribe.js voice.ogg --model large
-
-# Custom output directory
-node transcribe.js voice.ogg --output-dir ~/transcriptions/
-
-# Disable smart model, use environment default
-node transcribe.js voice.ogg --no-smart-model
-
-# Check dependencies
-node transcribe.js --check
-```
-
-### Environment Variables
-```bash
-WHISPER_MODEL=small      # Default model: tiny, base, small, medium, large
-WHISPER_LANGUAGE=auto    # Default language: auto, en, de, es, fr, etc.
-```
-
-**Model Sizes:**
-| Model | Size | Speed | Accuracy | RAM |
-|-------|------|-------|----------|-----|
-| tiny | 39 MB | ⚡⚡⚡⚡ | ⭐⭐ | ~1GB |
-| base | 74 MB | ⚡⚡⚡ | ⭐⭐⭐ | ~1GB |
-| small | 244 MB | ⚡⚡ | ⭐⭐⭐⭐ | ~2GB |
-| medium | 769 MB | ⚡ | ⭐⭐⭐⭐⭐ | ~5GB |
-| large | 1550 MB | 🐢 | ⭐⭐⭐⭐⭐ | ~10GB |
-
-**Recommendation:** Use smart model selection (default), or `small` model for balance of speed/accuracy
-
-### Smart Model Selection
-
-When enabled (default), the script automatically selects the best model based on file size:
-- **Files < 100KB**: Uses `large` model for maximum accuracy (short messages)
-- **Files ≥ 100KB**: Uses `medium` model for faster processing (longer messages)
-
-Disable with `--no-smart-model` to use your default or explicitly specified model.
-
-## Supported Formats
-
-**Input:**
-- WhatsApp OGG/Opus ✅
-- MP3
-- WAV
-- M4A
-- FLAC
-
-**Output:**
-- Plain text (.txt)
-- Subtitles (.srt, .vtt)
-- JSON with timestamps (.json)
-
-## Agent Integration
-
-All agents automatically handle voice messages:
-1. Voice message received (OGG format)
-2. Downloaded to `~/.openclaw/media/inbound/`
-3. Transcribed using local Whisper
-4. Text processed by agent
-5. Response generated
-
-## Troubleshooting
-
-**"ffmpeg: command not found"**
-→ Install FFmpeg (see Step 1 above)
-
-**"whisper: command not found"**
-→ Install Whisper: `pip install openai-whisper`
-
-**"No module named whisper"**
-→ Python package issue: `pip install --upgrade openai-whisper`
-
-**"CUDA out of memory"**
-→ Use smaller model: `WHISPER_MODEL=small node transcribe.js <file>`
-
-**Slow transcription**
-→ Use smaller model: tiny or base, or enable smart model selection
-
-## Installation Check
-
-```bash
-# Verify all dependencies
-node transcribe.js --check
-```
-
-Should show:
-```
-📦 Checking dependencies...
-
-  ffmpeg:   ✅
-  whisper:  ✅ (/home/art/.nix-profile/bin/whisper)
-  python3:  ✅
-```
-
-## Files
-
-- **Skill:** `~/.openclaw/skills/whisper/`
-- **Script:** `~/.openclaw/skills/whisper/transcribe.js`
-- **Media:** `~/.openclaw/media/inbound/`
-- **Transcriptions:** Saved alongside audio files (or to `--output-dir`)
+100% private voice transcription using OpenAI Whisper. Audio never leaves your machine.
 
 ## Quick Start
 
 ```bash
-# 1. Install dependencies (once)
+# Install dependencies
 pip install openai-whisper
 
-# 2. Transcribe a voice message
-node ~/.openclaw/skills/whisper/transcribe.js \
-  ~/.openclaw/media/inbound/750c9438-6e10-4aa7-9582-1264984d87af.ogg
-
-# 3. Get text output immediately!
+# Transcribe audio
+node transcribe.js voice.ogg
 ```
 
-## Development
+## CLI Options
 
-### Running Tests
-```bash
-node tests/transcribe.test.js
+```
+--model <tiny|base|small|medium|large>  Model size (default: small)
+--language <lang>                        Language code (default: auto)
+--output-dir <dir>                       Output directory
+--smart-model                           Auto-select model by file size
+--check                                 Verify dependencies
 ```
 
-### Project Structure
-```
-local-whisper/
-├── transcribe.js          # Main unified CLI
-├── tests/
-│   └── transcribe.test.js # Test suite
-└── SKILL.md               # This documentation
-```
+## Model Sizes
 
----
+| Model | Size | Speed | RAM |
+|-------|------|-------|-----|
+| tiny | 39 MB | ⚡⚡⚡⚡ | ~1GB |
+| base | 74 MB | ⚡⚡⚡ | ~1GB |
+| small | 244 MB | ⚡⚡ | ~2GB |
+| medium | 769 MB | ⚡ | ~5GB |
+| large | 1550 MB | 🐢 | ~10GB |
 
-**Status:** ✅ Unified CLI Ready | ⏳ Dependencies Required
+## Documentation
 
-**Next Step:** Install FFmpeg + Whisper (see Installation section above)
+- [Installation Guide](docs/INSTALL.md)
+- [Troubleshooting](docs/TROUBLESHOOTING.md)
+- [GitHub Repository](https://github.com/kesslerio/local-whisper-openclaw-skill)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,87 @@
+# Installation Guide
+
+## Prerequisites
+
+- Node.js (for the transcribe.js script)
+- Python 3 and pip (for Whisper)
+- FFmpeg (for audio format support)
+
+## Step 1: Install FFmpeg
+
+FFmpeg is required for audio format support.
+
+**NixOS:**
+```bash
+# Add to /etc/nixos/configuration.nix:
+environment.systemPackages = with pkgs; [ ffmpeg ];
+
+# Apply:
+sudo nixos-rebuild switch
+```
+
+**macOS:**
+```bash
+brew install ffmpeg
+```
+
+**Ubuntu/Debian:**
+```bash
+sudo apt install ffmpeg
+```
+
+**Arch Linux:**
+```bash
+sudo pacman -S ffmpeg
+```
+
+## Step 2: Install OpenAI Whisper
+
+```bash
+# Install Whisper
+pip install openai-whisper ffmpeg-python
+
+# Or with GPU support (NVIDIA):
+pip install openai-whisper[torch]
+
+# Verify installation
+whisper --help
+```
+
+## Step 3: Verify Installation
+
+```bash
+node transcribe.js --check
+```
+
+Expected output:
+```
+📦 Checking dependencies...
+
+  ffmpeg:   ✅
+  whisper:  ✅ (/path/to/whisper)
+  python3:  ✅
+```
+
+## Model Downloads
+
+Whisper automatically downloads models on first use:
+
+| Model | Size | Download Time |
+|-------|------|---------------|
+| tiny | 39 MB | ~10s |
+| base | 74 MB | ~20s |
+| small | 244 MB | ~1m |
+| medium | 769 MB | ~3m |
+| large | 1550 MB | ~6m |
+
+Models are cached in `~/.cache/whisper/`.
+
+## Environment Variables
+
+```bash
+export WHISPER_MODEL=small      # Default model
+export WHISPER_LANGUAGE=auto    # Default language
+export WHISPER_CMD=/path/to/whisper  # Custom whisper binary path
+```
+
+Add these to your shell profile (`.bashrc`, `.zshrc`, etc.) to make them persistent.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,107 @@
+# Troubleshooting Guide
+
+## Common Issues
+
+### "ffmpeg: command not found"
+
+**Cause:** FFmpeg is not installed or not in PATH.
+
+**Solution:**
+```bash
+# NixOS: Add to configuration.nix
+environment.systemPackages = with pkgs; [ ffmpeg ];
+
+# Then rebuild
+sudo nixos-rebuild switch
+```
+
+### "whisper: command not found"
+
+**Cause:** Whisper is not installed or not in PATH.
+
+**Solution:**
+```bash
+pip install openai-whisper
+
+# Verify
+whisper --help
+```
+
+If still not found, check your Python bin directory is in PATH:
+```bash
+# Add to your shell profile
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+### "No module named whisper"
+
+**Cause:** Python package not properly installed.
+
+**Solution:**
+```bash
+pip install --upgrade openai-whisper ffmpeg-python
+```
+
+### "CUDA out of memory"
+
+**Cause:** GPU doesn't have enough VRAM for the selected model.
+
+**Solutions:**
+1. Use a smaller model:
+   ```bash
+   node transcribe.js audio.ogg --model tiny
+   ```
+2. Set default model in environment:
+   ```bash
+   export WHISPER_MODEL=base
+   ```
+3. Use CPU instead of GPU (slower but works on any hardware)
+
+### Slow transcription
+
+**Solutions:**
+1. Use a smaller model:
+   ```bash
+   node transcribe.js audio.ogg --model tiny  # Fastest
+   node transcribe.js audio.ogg --model base   # Fast, good accuracy
+   ```
+
+2. Enable smart model selection (default):
+   ```bash
+   node transcribe.js audio.ogg --smart-model
+   ```
+
+### "Unsupported audio format"
+
+**Cause:** File format not in supported list.
+
+**Supported formats:** WAV, MP3, M4A, FLAC, OGG
+
+**Solution:** Convert to a supported format:
+```bash
+ffmpeg -i input.wma output.mp3
+```
+
+### Permission denied errors
+
+**Solution:**
+```bash
+# Make script executable
+chmod +x transcribe.js
+
+# Or run with node explicitly
+node transcribe.js audio.ogg
+```
+
+## Debug Mode
+
+Run with verbose output:
+```bash
+node transcribe.js audio.ogg --verbose 2>&1 | tee debug.log
+```
+
+## Getting Help
+
+1. Check the [GitHub Issues](https://github.com/kesslerio/local-whisper-openclaw-skill/issues)
+2. Run `node transcribe.js --check` to verify dependencies
+3. Check [OpenAI Whisper documentation](https://github.com/openai/whisper)


### PR DESCRIPTION
Closes #7

## Changes
- Slimmed SKILL.md from ~200 lines to ~30 lines
- Moved installation instructions to docs/INSTALL.md
- Moved troubleshooting content to docs/TROUBLESHOOTING.md
- Retained quick start, CLI flags summary, and model sizes table
- Added links to full documentation

## New Structure
- SKILL.md: Overview, quick start, key reference tables
- docs/INSTALL.md: Detailed installation steps
- docs/TROUBLESHOOTING.md: Common issues and solutions