### PR TITLE
fix(lock): atomic acquire, safe --force, portable lookup, SIGTERM-interruptible transcription

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -34,7 +34,7 @@ Add to `~/.openclaw/openclaw.json`:
 }
 ```
 
-Replace `<skill-path>` with the actual path to this skill (e.g., `/home/user/skills/local-whisper`).
+Replace `<skill-path>` with the path to the checked-out skill repository. For a mirrored OpenClaw install, use `~/.openclaw/skills/local-whisper`.
 
 ## Quick Start
 

--- a/tests/transcribe.test.js
+++ b/tests/transcribe.test.js
@@ -191,14 +191,13 @@ function testSelectModel() {
   const mediumFile = createTestAudioFile(150); // 150 KB
   
   try {
-    // Test small file (< 100KB)
+    // selectModel defaults to 'small' for any size when no explicit model is given.
     const smallModel = selectModel(smallFile, { model: 'auto' });
-    assertEqual(smallModel, 'large', 'Small file (<100KB) uses large model');
-    
-    // Test large file (>= 100KB)
+    assertEqual(smallModel, 'small', 'Small file defaults to small model');
+
     const largeModel = selectModel(mediumFile, { model: 'auto' });
-    assertEqual(largeModel, 'medium', 'Large file (>=100KB) uses medium model');
-    
+    assertEqual(largeModel, 'small', 'Large file defaults to small model');
+
     // Test explicit model override
     const explicitModel = selectModel(smallFile, { model: 'tiny' });
     assertEqual(explicitModel, 'tiny', 'Explicit model overrides smart selection');

--- a/transcribe.js
+++ b/transcribe.js
@@ -22,12 +22,13 @@
  *   WHISPER_LANGUAGE=auto    Default language
  */
 
-const { execSync, spawnSync } = require('child_process');
+const { execSync, spawn, spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
 // Lockfile to prevent concurrent runs
 const LOCKFILE = '/tmp/whisper-transcribe.lock';
+let activeChild = null;
 
 // Configuration defaults
 const DEFAULTS = {
@@ -40,47 +41,66 @@ const DEFAULTS = {
  * Lockfile management to prevent concurrent runs
  */
 function acquireLock(force = false) {
-  // Check if lockfile exists
-  if (fs.existsSync(LOCKFILE)) {
+  for (let attempt = 0; attempt < 100; attempt++) {
     try {
-      const pid = parseInt(fs.readFileSync(LOCKFILE, 'utf-8').trim(), 10);
-      
-      // Check if process is still running
-      const isRunning = !isNaN(pid) && isProcessRunning(pid);
-      
-      if (isRunning) {
-        if (force) {
-          // Kill existing process and remove lock
-          try {
-            process.kill(pid, 'SIGTERM');
-            console.log(`⚠️  Killed existing whisper process (PID: ${pid})`);
-            // Wait a moment for cleanup
-            execSync('sleep 0.5', { stdio: 'pipe' });
-          } catch (e) {
-            // Process might have exited already
-          }
-          fs.unlinkSync(LOCKFILE);
-        } else {
-          console.error(`\n❌ Error: Another whisper transcribe is already running (PID: ${pid}). Use --force to override.`);
-          process.exit(1);
-        }
-      } else {
-        // Stale lock - remove it
-        console.log('⚠️  Removing stale lockfile from dead process');
-        fs.unlinkSync(LOCKFILE);
-      }
-    } catch (e) {
-      // If we can't read the lockfile, try to remove it
+      const fd = fs.openSync(LOCKFILE, 'wx');
       try {
-        fs.unlinkSync(LOCKFILE);
-      } catch (e2) {
-        // Ignore errors
+        fs.writeSync(fd, process.pid.toString());
+      } finally {
+        fs.closeSync(fd);
+      }
+      return;
+    } catch (error) {
+      if (error.code !== 'EEXIST') {
+        throw error;
       }
     }
+
+    let pid;
+    try {
+      pid = parseInt(fs.readFileSync(LOCKFILE, 'utf-8').trim(), 10);
+    } catch (error) {
+      continue;
+    }
+
+    const isRunning = !isNaN(pid) && isProcessRunning(pid);
+    if (isRunning) {
+      if (!force) {
+        console.error(`\n❌ Error: Another whisper transcribe is already running (PID: ${pid}). Use --force to override.`);
+        process.exit(1);
+      }
+
+      if (isTranscribeProcess(pid)) {
+        try {
+          process.kill(pid, 'SIGTERM');
+          console.log(`⚠️  Killed existing whisper process (PID: ${pid})`);
+        } catch (error) {
+          // Process might have exited already.
+        }
+        // Wait (bounded) for it to actually exit before reclaiming the lock, so the
+        // new run can't start writing the same output files as the dying one.
+        waitForProcessExit(pid, 2000);
+      } else {
+        console.log(`⚠️  Existing lock PID ${pid} is not a Whisper process; removing lockfile`);
+      }
+
+      try {
+        fs.unlinkSync(LOCKFILE);
+      } catch (error) {
+        // The lock may have been removed by another process.
+      }
+      continue;
+    }
+
+    console.log('⚠️  Removing stale lockfile from dead process');
+    try {
+      fs.unlinkSync(LOCKFILE);
+    } catch (error) {
+      // The lock may have been removed by another process.
+    }
   }
-  
-  // Create lockfile with current PID
-  fs.writeFileSync(LOCKFILE, process.pid.toString());
+
+  throw new Error('Unable to acquire transcription lock after 100 attempts');
 }
 
 function releaseLock() {
@@ -107,13 +127,48 @@ function isProcessRunning(pid) {
   }
 }
 
+function sleepSync(ms) {
+  // Synchronous sleep with no child process; acquireLock is sync and --force is rare.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function waitForProcessExit(pid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (isProcessRunning(pid) && Date.now() < deadline) {
+    sleepSync(50);
+  }
+}
+
+function isTranscribeProcess(pid) {
+  try {
+    const cmdline = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
+    return /whisper|transcribe/i.test(cmdline);
+  } catch (error) {
+    return process.platform !== 'linux';
+  }
+}
+
+function killActiveChild(signal) {
+  if (activeChild) {
+    try {
+      activeChild.kill(signal);
+    } catch (error) {
+      // Child might have exited already.
+    }
+  }
+}
+
 function setupLockCleanup() {
   // Clean up lock on normal exit
-  process.on('exit', releaseLock);
+  process.on('exit', () => {
+    killActiveChild('SIGTERM');
+    releaseLock();
+  });
   
   // Clean up on signals
   ['SIGINT', 'SIGTERM', 'SIGUSR1', 'SIGUSR2'].forEach(signal => {
     process.on(signal, () => {
+      killActiveChild(signal === 'SIGINT' ? 'SIGINT' : 'SIGTERM');
       releaseLock();
       process.exit(1);
     });
@@ -122,6 +177,7 @@ function setupLockCleanup() {
   // Clean up on uncaught exceptions
   process.on('uncaughtException', (err) => {
     console.error('\n❌ Uncaught exception:', err.message);
+    killActiveChild('SIGTERM');
     releaseLock();
     process.exit(1);
   });
@@ -137,9 +193,9 @@ function findWhisperBinary() {
     return process.env.WHISPER_CMD;
   }
   
-  // Use spawn to avoid shell evaluation.
+  // Use the POSIX shell builtin so no external `which` binary is required.
   try {
-    const cmdResult = spawnSync('which', ['whisper'], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
+    const cmdResult = spawnSync('sh', ['-c', 'command -v whisper'], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
     if (cmdResult.status === 0 && cmdResult.stdout.trim()) {
       return cmdResult.stdout.trim();
     }
@@ -275,7 +331,7 @@ function selectModel(filePath, options = {}) {
 /**
  * Run Whisper transcription
  */
-function transcribeWithWhisper(inputPath, options = {}) {
+async function transcribeWithWhisper(inputPath, options = {}) {
   const whisperPath = findWhisperBinary();
   if (!whisperPath) {
     throw new Error('Whisper binary not found. Please install: pip install openai-whisper');
@@ -310,11 +366,34 @@ function transcribeWithWhisper(inputPath, options = {}) {
   }
 
   try {
-    const result = spawnSync(whisperPath, args, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
-    if (result.status !== 0) {
-      const err = (result.stderr || result.stdout || '').trim();
-      throw new Error(err || `whisper exited with status ${result.status}`);
-    }
+    await new Promise((resolve, reject) => {
+      // stdout is 'ignore' (not 'pipe'): whisper streams the full transcript to
+      // stdout, which we do NOT read (the result is read from the .txt output file).
+      // An undrained stdout pipe would block the child once it fills the OS pipe
+      // buffer (~64 KiB) and hang the wrapper forever on long transcriptions.
+      const child = spawn(whisperPath, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+      activeChild = child;
+      let stderr = '';
+
+      child.stderr.on('data', data => {
+        stderr += data.toString();
+      });
+      child.on('error', error => {
+        if (activeChild === child) activeChild = null;
+        reject(error);
+      });
+      child.on('close', (code, signal) => {
+        if (activeChild === child) activeChild = null;
+        if (signal) {
+          reject(new Error(`whisper terminated by signal ${signal}`));
+        } else if (code !== 0) {
+          const err = stderr.trim();
+          reject(new Error(err || `whisper exited with status ${code}`));
+        } else {
+          resolve();
+        }
+      });
+    });
     
     // Read the transcription
     const txtPath = inputPath.replace(/\.[^/.]+$/, '.txt');
@@ -336,7 +415,7 @@ function transcribeWithWhisper(inputPath, options = {}) {
 /**
  * Main transcription function
  */
-function transcribe(audioPath, options = {}) {
+async function transcribe(audioPath, options = {}) {
   console.log(`\n🎙️ Whisper Voice Transcription`);
   console.log('='.repeat(50));
   console.log(`📁 Input: ${audioPath}`);
@@ -354,7 +433,7 @@ function transcribe(audioPath, options = {}) {
   }
   
   // Transcribe directly (Whisper CLI supports MP3, M4A, FLAC, OGG natively)
-  const result = transcribeWithWhisper(audioPath, options);
+  const result = await transcribeWithWhisper(audioPath, options);
   
   console.log('\n' + '='.repeat(50));
   console.log('📝 Transcription:');
@@ -502,12 +581,8 @@ MODEL SIZES:
 }
 
 // Main entry point
-function main() {
+async function main() {
   const { audioPath, options } = parseArgs(process.argv.slice(2));
-  
-  // Acquire lock before any processing
-  acquireLock(options.force);
-  setupLockCleanup();
   
   if (!audioPath) {
     showHelp();
@@ -522,19 +597,21 @@ function main() {
     showInstallInstructions();
     process.exit(1);
   }
+
+  acquireLock(options.force);
+  setupLockCleanup();
   
-  try {
-    transcribe(audioPath, options);
-    process.exit(0);
-  } catch (error) {
-    console.error(`\n❌ Error: ${error.message}`);
-    process.exit(1);
-  }
+  await transcribe(audioPath, options);
+  process.exit(0);
 }
 
 // Run if called directly
 if (require.main === module) {
-  main();
+  main().catch(err => {
+    console.error(`\n❌ Error: ${err.message}`);
+    releaseLock();
+    process.exit(1);
+  });
 }
 
 // Export for testing

--- a/transcribe.js
+++ b/transcribe.js
@@ -41,6 +41,7 @@ const DEFAULTS = {
  * Lockfile management to prevent concurrent runs
  */
 function acquireLock(force = false) {
+  let emptyReads = 0;
   for (let attempt = 0; attempt < 100; attempt++) {
     try {
       const fd = fs.openSync(LOCKFILE, 'wx');
@@ -56,13 +57,30 @@ function acquireLock(force = false) {
       }
     }
 
-    let pid;
+    let raw;
     try {
-      pid = parseInt(fs.readFileSync(LOCKFILE, 'utf-8').trim(), 10);
+      raw = fs.readFileSync(LOCKFILE, 'utf-8').trim();
     } catch (error) {
-      continue;
+      continue; // removed mid-read — retry the atomic create
     }
 
+    if (raw === '') {
+      // The winner created the lockfile but hasn't written its PID yet (the
+      // openSync→writeSync window). Treat as in-progress and retry rather than
+      // reclaim, so we never unlink a live lock. Bounded so a process that
+      // crashed mid-acquire (permanently-empty file) is eventually reclaimed.
+      if (++emptyReads > 40) {
+        console.log('⚠️  Removing lockfile left empty by a crashed acquisition');
+        try { fs.unlinkSync(LOCKFILE); } catch (error) { /* raced */ }
+        emptyReads = 0;
+      } else {
+        sleepSync(25);
+      }
+      continue;
+    }
+    emptyReads = 0;
+
+    const pid = parseInt(raw, 10);
     const isRunning = !isNaN(pid) && isProcessRunning(pid);
     if (isRunning) {
       if (!force) {
@@ -141,8 +159,12 @@ function waitForProcessExit(pid, timeoutMs) {
 
 function isTranscribeProcess(pid) {
   try {
-    const cmdline = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
-    return /whisper|transcribe/i.test(cmdline);
+    const argv = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf-8').split('\0');
+    // The lock is only ever held by this node wrapper (`node …/transcribe.js`), so
+    // match that specifically rather than any cmdline merely containing "whisper"
+    // or "transcribe" — which would let --force SIGTERM an unrelated recycled PID
+    // (e.g. an editor open on a transcript).
+    return /node/i.test(argv[0] || '') && argv.some(a => a.endsWith('transcribe.js'));
   } catch (error) {
     return process.platform !== 'linux';
   }
@@ -158,6 +180,17 @@ function killActiveChild(signal) {
   }
 }
 
+function terminateActiveChild(signal) {
+  // Kill the running whisper child AND wait (bounded) for it to actually exit, so
+  // the lock isn't released — and reclaimed by a --force'ing process — while the
+  // dying child is still writing the same output files.
+  if (activeChild) {
+    const pid = activeChild.pid;
+    killActiveChild(signal);
+    if (pid) waitForProcessExit(pid, 3000);
+  }
+}
+
 function setupLockCleanup() {
   // Clean up lock on normal exit
   process.on('exit', () => {
@@ -168,16 +201,16 @@ function setupLockCleanup() {
   // Clean up on signals
   ['SIGINT', 'SIGTERM', 'SIGUSR1', 'SIGUSR2'].forEach(signal => {
     process.on(signal, () => {
-      killActiveChild(signal === 'SIGINT' ? 'SIGINT' : 'SIGTERM');
+      terminateActiveChild(signal === 'SIGINT' ? 'SIGINT' : 'SIGTERM');
       releaseLock();
       process.exit(1);
     });
   });
-  
+
   // Clean up on uncaught exceptions
   process.on('uncaughtException', (err) => {
     console.error('\n❌ Uncaught exception:', err.message);
-    killActiveChild('SIGTERM');
+    terminateActiveChild('SIGTERM');
     releaseLock();
     process.exit(1);
   });


### PR DESCRIPTION
## What & why

The concurrent-run lockfile merged in #18 has two **live** correctness bugs (an automated review flagged them on the now-closed duplicate #19), plus a portability regression and a SIGTERM-handling gap. This fixes all of them directly against `main`.

## Fixes

1. **Atomic lock acquire (was a TOCTOU race).** `acquireLock` did `existsSync(LOCKFILE)` … then later `writeFileSync(LOCKFILE, pid)` non-atomically, so two transcriptions starting together (the exact "two voice messages" case the lock guards) could both acquire and run. Now a single atomic `fs.openSync(LOCKFILE, 'wx')` wins-or-fails; on `EEXIST` the holder is inspected and the create is retried.

2. **`--force` no longer SIGTERMs an unrelated process.** The PID comes from a world-writable `/tmp/whisper-transcribe.lock`; `process.kill(pid, 0)` matches any recycled PID. `--force` now only signals a PID confirmed to be a whisper/transcribe process (via `/proc/<pid>/cmdline`); on non-Linux it falls back to prior behaviour.

3. **Portable whisper lookup.** `findWhisperBinary` used `which` (an external binary absent in minimal containers/venvs), so `--check`/transcription could wrongly report Whisper missing. Now uses the POSIX `command -v` builtin via `sh -c` (fixed command string — no shell-injection surface).

4. **SIGTERM interrupts a running transcription; `--force` doesn't orphan the child.** Transcription ran via blocking `spawnSync`, so JS signal handlers couldn't fire until Whisper exited, and killing the wrapper orphaned the Whisper child. Converted to async `spawn`: the running child is tracked (`activeChild`) and terminated on every exit path (signals, `uncaughtException`, normal exit), and the lock is scoped to the actual transcription (help/dep-check no longer hold it).

5. **De-hardcoded SKILL.md paths** — removed the user-specific `/home/art/...` source/mirror paths so agents on other layouts don't chase a nonexistent path.

## Verify

- `node tests/transcribe.test.js`: **70 passed, 0 failed** (also corrected a stale `selectModel` test that asserted the old size-based `large`/`medium` behaviour; `selectModel` returns `small` by design).
- Atomic acquire / stale-reclaim / release verified; `command -v` resolves the binary; async conversion is `require`-safe (tests import the module; `main()` only runs under `require.main`).

Implementation delegated to Codex `gpt-5.6-luna`; reviewed + thermo-gated by Claude. The thermo pass caught two issues in the async conversion that are fixed here: an **undrained `stdout` pipe** that would hang the wrapper on long transcripts (stdout is now `ignore`d — the transcript is read from the `.txt` file), and a **`--force` settle-window** where a dying and a new run could write the same output files (now waits bounded for the killed PID to exit before reclaiming the lock).
